### PR TITLE
chore: add CLAUDE.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,5 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+.claude
+CLAUDE.md


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` to `.gitignore` alongside the existing `.claude` directory entry to keep Claude Code configuration files out of version control.

## Test plan
- [x] Verify `CLAUDE.md` is excluded from `git status` after the change