### PR TITLE
[IN-0001] Add permissions block to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

- Adds top-level `permissions: contents: read` to `ci.yml`, following the principle of least privilege
- All three jobs (lint, test, build) only need read access to checkout the repo and upload artifacts
- The other workflows (`publish.yml`, `publish-testpypi.yml`, `release.yml`) already had explicit permissions

## CodeQL alerts resolved

- Workflow does not contain permissions (lint job, line 13)
- Workflow does not contain permissions (test job, line 38)
- Workflow does not contain permissions (build job, line 67)

## Test plan

- [ ] CI workflow runs successfully on this PR
- [ ] CodeQL no longer flags missing permissions on `ci.yml`